### PR TITLE
Fix timezone issue on 'Power Consumption Values per day'

### DIFF
--- a/grafana.dashboard.json
+++ b/grafana.dashboard.json
@@ -1299,6 +1299,8 @@
           "measurement": "conso_elec",
           "orderByTime": "ASC",
           "policy": "default",
+          "query": "SELECT sum(\"value\") FROM \"conso_elec\" WHERE $timeFilter GROUP BY time(1d) fill(null) tz('Europe/Paris')",
+          "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
           "select": [


### PR DESCRIPTION
In influxDB data are store in UTC time so the group by time(1d) is grouping with a 2h of shift
It's was possible to use something like :
```
SELECT sum(\"value\") FROM \"conso_elec\" WHERE $timeFilter GROUP BY time(1d,-2h) fill(null)
```
But look like less portable than specify the TimeZone (  tz('Europe/Paris') )